### PR TITLE
Fix: Action simulation with non-UUID ids

### DIFF
--- a/server/debugging/actionsimulation/action_simulation.go
+++ b/server/debugging/actionsimulation/action_simulation.go
@@ -54,10 +54,10 @@ func (sim ActionSimulation) GetSteps() ([]responses.Step, bool) {
 
 	// State == staging with testusers and matching channel
 	if sim.Action.Action.State == db.StateStaging {
-		if !sim.Action.HasTestUser(sim.User.UserID.String(), sim.User.Channel) {
+		if !sim.Action.HasTestUser(sim.User.UserID, sim.User.Channel) {
 			step.Info = "User is not a testuser of this staging action."
 			step.State = "error"
-		} else if sim.Action.SkipTargeting(sim.User.UserID.String(), sim.User.Channel) {
+		} else if sim.Action.SkipTargeting(sim.User.UserID, sim.User.Channel) {
 			step.Info = "User skips targeting."
 		}
 	} else {

--- a/server/platform/requests/action_simulation.go
+++ b/server/platform/requests/action_simulation.go
@@ -2,8 +2,6 @@ package requests
 
 import (
 	"encoding/json"
-
-	"github.com/gofrs/uuid"
 )
 
 type ActionSimulation struct {
@@ -11,9 +9,9 @@ type ActionSimulation struct {
 }
 
 type ActionSimulationUser struct {
-	UserID   uuid.UUID `json:"userId"`
-	Channel  string    `json:"channel"`
-	ActionID string    `json:"actionId"`
+	UserID         string          `json:"userId"`
+	Channel        string          `json:"channel"`
+	ActionID       string          `json:"actionId"`
 	ComputedTraits json.RawMessage `json:"computedTraits"`
 	CustomTraits   json.RawMessage `json:"customTraits"`
 	Context        json.RawMessage `json:"context"`


### PR DESCRIPTION
Action simulation with user IDs of type string were not possible.